### PR TITLE
Add some test for attributes modifier

### DIFF
--- a/test/fixtures/property-modifiers.less
+++ b/test/fixtures/property-modifiers.less
@@ -86,3 +86,13 @@
 // :disabled - DISABLED
 //
 // Style guide: modifiers.after-description
+
+// Attributes modifiers
+//
+// Markup: <div>
+//
+// [aria-hidden=true] - hidden
+// [aria-busy="true"] - loading
+// [required]         - required
+//
+// Style guide: modifiers.attributes

--- a/test/fixtures/source-handlebars-builder-test/1c.hbs
+++ b/test/fixtures/source-handlebars-builder-test/1c.hbs
@@ -1,4 +1,4 @@
-<div class="{{modifier_class}}">
+<div class="{{modifier_class}}" {{modifier_attribute}}>
   <h1>1c</h1>
   <p>
     {{content}}

--- a/test/fixtures/source-handlebars-builder-test/kss-source.scss
+++ b/test/fixtures/source-handlebars-builder-test/kss-source.scss
@@ -16,6 +16,9 @@
 //
 // .modifier-1 - Modifier #1
 // :hover - Modifier Hover
+// [data-modifier] - attribute modifier
+// [data-modifier=modifier] - attribute modifier with value
+// [data-modifier="other modifier"] - attribute modifier with quoted value
 //
 // Style guide: 1.C
 

--- a/test/fixtures/source-twig-builder-test/1c.twig
+++ b/test/fixtures/source-twig-builder-test/1c.twig
@@ -1,4 +1,4 @@
-<div class="{{ modifier_class }}">
+<div class="{{ modifier_class }}" {{ modifier_attribute }}>
   <h1>1c</h1>
   <p>
     {{ content }}

--- a/test/fixtures/source-twig-builder-test/kss-source.scss
+++ b/test/fixtures/source-twig-builder-test/kss-source.scss
@@ -16,6 +16,9 @@
 //
 // .modifier-1 - Modifier #1
 // :hover - Modifier Hover
+// [data-modifier] - attribute modifier
+// [data-modifier=modifier] - attribute modifier with value
+// [data-modifier="other modifier"] - attribute modifier with quoted value
 //
 // Style guide: 1.C
 

--- a/test/test_kss_builder_base_handlebars.js
+++ b/test/test_kss_builder_base_handlebars.js
@@ -308,8 +308,8 @@ describe('KssBuilderBaseHandlebars object API', function() {
       expect(this.files['section-1']).to.include('ref:1.A:no-markup:\n');
     });
 
-    it('should add modifier_class from the JSON data', function() {
-      expect(this.files['section-1']).to.include('ref:1.C:markup:<div class="one-cee-from-json [modifier class]">');
+    it('should add modifier_class and modifier_attribute from the JSON data', function() {
+      expect(this.files['section-1']).to.include('ref:1.C:markup:<div class="one-cee-from-json [modifier class]" [modifier attribute]>');
     });
 
     it('should add modifier_class from the example JSON data', function() {

--- a/test/test_kss_builder_base_twig.js
+++ b/test/test_kss_builder_base_twig.js
@@ -363,8 +363,8 @@ describe('KssBuilderBaseTwig object API', function() {
       expect(this.files['section-1']).to.include('ref:1.A:no-example:\n');
     });
 
-    it('should add modifier_class from the JSON data', function() {
-      expect(this.files['section-1']).to.include('ref:1.C:markup:<div class="one-cee-from-json [modifier class]">');
+    it('should add modifier_class and modifier_attribute from the JSON data', function() {
+      expect(this.files['section-1']).to.include('ref:1.C:markup:<div class="one-cee-from-json [modifier class]" [modifier attribute]>');
     });
 
     it('should add modifier_class from the example JSON data', function() {

--- a/test/test_parse.js
+++ b/test/test_parse.js
@@ -276,6 +276,12 @@ describe('kss.parse()', function() {
           expect(modifiers.length).to.equal(2);
           done();
         });
+
+        it('should find attributes modifiers', function(done) {
+          let modifiers = this.styleGuide.sections('modifiers.attributes').modifiers();
+          expect(modifiers.length).to.equal(3);
+          done();
+        });
       });
 
       describe('.deprecated/.experimental', function() {


### PR DESCRIPTION
But unfortunately some test fail.
The `[modifier attribute]` placeholder do not appear in the result whatever the builder used (twig or handlebars).

- [x] test if a modifier attribute is recognized as modifier
- [x] test if [modifier_attribute] placeholder is in the result (twig and handlebars) **fail** 
- [ ] test if modifier attribute is in the result (twig and handlebars)
- [ ] test if modifier attribute without value
- [ ] test if modifier attribute with value with quotes
- [ ] test if modifier attribute with value without quote works fine